### PR TITLE
Fix cartridge overwriting

### DIFF
--- a/src/cartridge.js
+++ b/src/cartridge.js
@@ -41,7 +41,7 @@ function getCartridgeDetails (cartridgePath) {
     let content, section;
 
     // Extract the contents of each section
-    const regex = /__([a-z]+)__\n([\s\S]*?)(?=\n__\w+__\n|\n\n)/g;
+    const regex = /__([a-z]+)__\n([\s\S]*?)(?=\n__\w+__\n|\n(\n|$))/g;
     while ([, section, content] = regex.exec(contents) || "") { // eslint-disable-line no-cond-assign
       if (section !== "lua") {
         result[section] = content;


### PR DESCRIPTION
Addresses #7

It looks like the regex expects that there will always be a line break at the end of the cartridge. Since that is not the case (or maybe, no longer the case as of some newer version of PICO-8) the result is that it will find every section aside from the last section. This continues with each save until only the lua section is left. The fix is to alter the regex to allow for a line break OR the end of the file.

Tested with PICO-8 v0.1.11g for Mac.